### PR TITLE
ci: add lint and test workflows (PR-2)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,70 @@
+# Lint workflow — Van Gogh Living Scene
+# Enforces coding standards from CLAUDE.md via ruff + mypy.
+# Standards: NIST SA-11, PEP 604, OWASP A04/A05.
+#
+# Initial rollout is report-only (continue-on-error). Once existing
+# violations are cleared in scoped follow-up PRs, flip the flags to
+# make this workflow blocking.
+
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: ruff + mypy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dev tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Ruff format check
+        id: ruff-format
+        continue-on-error: true
+        run: ruff format --check .
+
+      - name: Ruff lint
+        id: ruff-lint
+        continue-on-error: true
+        run: ruff check . --output-format=github
+
+      - name: Mypy strict type check
+        id: mypy
+        continue-on-error: true
+        run: mypy src tools
+
+      - name: Summarise lint results
+        if: always()
+        run: |
+          {
+            echo "## Lint results"
+            echo ""
+            echo "| Check | Outcome |"
+            echo "|-------|---------|"
+            echo "| ruff format --check | ${{ steps.ruff-format.outcome }} |"
+            echo "| ruff check | ${{ steps.ruff-lint.outcome }} |"
+            echo "| mypy src tools | ${{ steps.mypy.outcome }} |"
+            echo ""
+            echo "Report-only mode — see individual step logs for details."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,98 @@
+# Test workflow — Van Gogh Living Scene
+# Runs pytest with coverage in report-only mode.
+# Standards: NIST SA-11 (SEC-07 unit test coverage).
+#
+# Hardware-dependent tests (@pytest.mark.hardware) are skipped on
+# GitHub runners. Full compliance testing runs on the target Pi via
+# scripts/compliance-check.sh (see docs/release-checklist.md in PR-7).
+#
+# Coverage gating is intentionally disabled at rollout (per decision
+# 2026-04-05). A baseline will be established, then a floor applied
+# in a follow-up PR.
+
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest (not hardware)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install CI runtime deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-ci.txt
+
+      - name: Run pytest with coverage
+        id: pytest
+        continue-on-error: true
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          pytest tests/ \
+            -m "not hardware" \
+            --cov=src \
+            --cov-report=xml:coverage.xml \
+            --cov-report=html:htmlcov \
+            --cov-report=term \
+            --junitxml=pytest-report.xml
+
+      - name: Upload coverage XML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload coverage HTML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-junit
+          path: pytest-report.xml
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Summarise test results
+        if: always()
+        run: |
+          {
+            echo "## Test results"
+            echo ""
+            echo "pytest outcome: **${{ steps.pytest.outcome }}**"
+            echo ""
+            echo "Report-only mode — artifacts: coverage-xml, coverage-html, pytest-junit."
+            echo ""
+            echo "Hardware-dependent tests skipped (GitHub runners have no IMX500/Inky)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.yamllint
+++ b/.yamllint
@@ -19,7 +19,7 @@ rules:
 
   # Comments should have a space after the '#'.
   comments:
-    require-starts-with-space: true
+    require-starting-space: true
     min-spaces-from-content: 1
 
   # Allow "yes/no" and "on/off" (used in systemd-style configs).


### PR DESCRIPTION
## Summary
Second CI PR. Adds two GitHub Actions workflows in **report-only mode** (continue-on-error) so they establish a baseline without blocking merges. Follow-up PRs will fix violations and flip the flags to enforcing.

## Workflows added
- **`.github/workflows/lint.yml`** — runs on push/PR to main + manual dispatch
  - \`ruff format --check .\`
  - \`ruff check . --output-format=github\` (annotations in PR diff)
  - \`mypy src tools\` (strict)
  - Posts an at-a-glance summary table to \`\$GITHUB_STEP_SUMMARY\`
- **\`.github/workflows/test.yml\`** — runs on push/PR to main + manual dispatch
  - Installs portable deps from \`requirements-ci.txt\`
  - Runs \`pytest -m \"not hardware\"\` with coverage
  - Uploads 3 artifacts (30-day retention): \`coverage-xml\`, \`coverage-html\`, \`pytest-junit\`

## Bugfix included
Fixes \`.yamllint\` option name committed in PR-1: \`require-starts-with-space\` → \`require-starting-space\` (verified against yamllint 1.38.0 source).

## Baseline captured locally
- ruff: **45 findings** in \`src/\` + \`tools/\` (will be triaged and fixed in scoped follow-up PRs)
- mypy / pytest baselines: first workflow run will record them

## Design decisions
| Choice | Why |
|---|---|
| \`continue-on-error: true\` on every check | Per decision 2026-04-05: report-only until violations are cleared |
| Hardware tests skipped (\`-m \"not hardware\"\`) | GitHub runners lack IMX500/Inky; full compliance runs on Pi via \`scripts/compliance-check.sh\` (PR-7) |
| \`PYTHONPATH=\${{ github.workspace }}\` | Tests do \`from src.camera import …\` — needs repo root importable |
| Python 3.13 only | Target is Raspberry Pi OS Bookworm with Python 3.13 (see CLAUDE.md) |
| Pip cache via \`actions/setup-python@v5\` | Speed; no security implications (deps still resolved from PyPI) |
| \`permissions: contents: read\` | Least privilege — workflows do not write to repo |

## Test plan
- [ ] Workflows trigger on this PR; both jobs complete (even with findings)
- [ ] lint job summary table renders in Actions UI
- [ ] test job uploads 3 artifacts
- [ ] \`actionlint\` on workflow files produces no errors (can be added in security.yml, PR-3)

## Known limitations (to be addressed in follow-up)
- Tests import \`src.camera\`/\`src.display\`/etc., which transitively import \`picamera2\`, \`inky\`, \`rembg\`, \`ai_edge_litert\`. CI install only provides the portable subset. If any test module imports a hardware dep at top level, collection will fail; \`continue-on-error\` keeps the job green and the failure is visible in the JUnit artifact. Fixing this (either via \`sys.modules\` stubs in \`conftest.py\` or lazy imports in source) belongs in a scoped follow-up issue, not this PR.

Related: #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code linting workflow to validate code quality, formatting, and type checking on every push and pull request to the main branch.
  * Established automated test execution workflow with code coverage analysis and detailed reporting artifacts.
  * Updated linting configuration for improved validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->