### PR TITLE
fix: allow source builds in bundle-offline.sh on native aarch64

### DIFF
--- a/scripts/bundle-offline.sh
+++ b/scripts/bundle-offline.sh
@@ -207,13 +207,7 @@ if [[ "${ARCH}" != "aarch64" ]]; then
         --only-binary=":all:"
     )
 else
-    printf 'INFO: Native aarch64 download\n'
-    PIP_ARGS+=(
-        --python-version "3.13"
-        --implementation "cp"
-        --abi "cp313"
-        --only-binary=":all:"
-    )
+    printf 'INFO: Native aarch64 download (no platform constraints needed)\n'
 fi
 
 pip "${PIP_ARGS[@]}"


### PR DESCRIPTION
## Summary

- Remove `--only-binary=":all:"` and `--python-version`/`--platform`/`--abi` flags from the native aarch64 pip download path in `bundle-offline.sh`
- On native aarch64, pip naturally targets the local platform and can build C extensions from source (e.g. `spidev==3.8` which has no pre-built wheel)
- Cross-platform path (x86_64 → aarch64) retains `--only-binary=":all:"` since source builds can't target a foreign architecture

Found during first real run of the offline bundle workflow — `spidev==3.8` only ships as a source distribution and blocked the download.

## Test plan

- [x] `bundle-offline.sh` completes successfully on native aarch64 (Pi 5)
- [x] All 40 pip packages downloaded (including spidev built from source)
- [x] All 3 models downloaded and checksum verified
- [x] Bundle archive created: 315 MB, 43 manifest entries
- [x] `spidev-3.8` confirmed to build from source on Pi Zero 2W
- [ ] `shellcheck scripts/bundle-offline.sh` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pip constraint handling for aarch64 architecture builds in offline bundling. The script now correctly applies base pip arguments without redundant platform constraints on aarch64 systems, while maintaining existing behavior for other architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->