### PR TITLE
fix: align config.yaml detection labels with test fixture

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,8 +20,6 @@ detection:
     - "person"
     - "cat"
     - "dog"
-    - "bird"
-    - "horse"
 
 presence:
   entering_frames: 8     # consecutive detections to confirm entry (at 5 fps)


### PR DESCRIPTION
## Summary

- Remove `bird` and `horse` from `config/config.yaml` detection labels — the IMX500 MobileNetV2 SSD model is not trained to detect these with usable confidence
- Aligns production config with `tests/conftest.py` `sample_config` fixture

Closes #11

## Test plan

- [ ] `pytest tests/` passes (no test depends on bird/horse labels)
- [ ] Config validator accepts the 3-label list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated the object detection system configuration to recognize only person, cat, and dog objects in images and video
  * Removed detection capabilities for bird and horse objects from the available detection categories
  * The detection system now supports a refined set of object recognition categories with newly updated configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->