### PR TITLE
fix: align config.yaml detection labels with test fixture (#11)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,8 +20,6 @@ detection:
     - "person"
     - "cat"
     - "dog"
-    - "bird"
-    - "horse"
 
 presence:
   entering_frames: 8     # consecutive detections to confirm entry (at 5 fps)


### PR DESCRIPTION
Remove bird and horse from detection labels — IMX500 MobileNetV2 SSD model is not trained to detect these with usable confidence. Aligns production config with tests/conftest.py sample_config.

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Enhanced object detection to recognize persons, cats, and dogs
  * Removed bird and horse detection from supported labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->